### PR TITLE
DEVO-1055 - bump to Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jobs:
       - name: Process jest results with default
         if: always()
         # You may also reference just the major or major.minor version
-        uses: im-open/process-jest-test-results@v2.2.2
+        uses: im-open/process-jest-test-results@v2.2.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: 'src/ProjectWithJestTests/jest-results.json
@@ -137,7 +137,7 @@ jobs:
       
       - name: Process jest results
         id: process-jest
-        uses: im-open/process-jest-test-results@v2.2.2
+        uses: im-open/process-jest-test-results@v2.2.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: 'jest.json'

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ jobs:
       - name: Process jest results with default
         if: always()
         # You may also reference just the major or major.minor version
-        uses: im-open/process-jest-test-results@v2.2.3
+        uses: im-open/process-jest-test-results@v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: 'src/ProjectWithJestTests/jest-results.json
@@ -137,7 +137,7 @@ jobs:
       
       - name: Process jest results
         id: process-jest
-        uses: im-open/process-jest-test-results@v2.2.3
+        uses: im-open/process-jest-test-results@v3.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           results-file: 'jest.json'

--- a/action.yml
+++ b/action.yml
@@ -61,5 +61,5 @@ outputs:
     description: 'The ID of the PR comment that was created.  This is only set if `create-pr-comment` is `true` and a PR was created successfully.'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
# Summary of PR changes

Bumped the Node.js runtime from `node20` to `node24` in `action.yml` and updated the README usage examples to `v3.0.0`.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version. For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*